### PR TITLE
Optimize progress handling

### DIFF
--- a/plugin/Jellyfin.Plugin.Jellydash.Tests/ImageCaptureServiceTests.cs
+++ b/plugin/Jellyfin.Plugin.Jellydash.Tests/ImageCaptureServiceTests.cs
@@ -6,9 +6,7 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Model.Drawing;
 using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.IO;
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/plugin/Jellyfin.Plugin.Jellydash.Tests/PlaybackEntryRepositoryTests.cs
+++ b/plugin/Jellyfin.Plugin.Jellydash.Tests/PlaybackEntryRepositoryTests.cs
@@ -389,4 +389,74 @@ public class PlaybackEntryRepositoryTests
             IsCompleted = endUtc.HasValue
         };
     }
+
+    [Fact]
+    public async Task DeleteByIdAsync_ExistingEntry_DeletesEntry()
+    {
+        var repository = new PlaybackEntryRepository(DatabaseHelper);
+        var cancellationToken = CancellationToken.None;
+
+        // Ensure a clean database.
+        await CleanDatabaseAsync(repository);
+
+        var now = DateTimeOffset.UtcNow;
+        var entry = CreateEntry(now.AddMinutes(-10), now, ContentType.Movie);
+
+        await repository.AppendAsync(entry, cancellationToken);
+
+        // Verify entry exists
+        var playbackId = entry.PlaybackId;
+        var retrieved = await repository.GetRecentlyCompletedByPlaybackIdAsync(playbackId, cancellationToken);
+        Assert.NotNull(retrieved);
+
+        // Delete the entry
+        var deletedCount = await repository.DeleteByIdAsync(retrieved.Id, cancellationToken);
+        Assert.Equal(1, deletedCount);
+
+        // Verify entry no longer exists
+        var afterDelete = await repository.GetRecentlyCompletedByPlaybackIdAsync(playbackId, cancellationToken);
+        Assert.Null(afterDelete);
+    }
+
+    [Fact]
+    public async Task DeleteByIdAsync_NonExistentEntry_ReturnsZero()
+    {
+        var repository = new PlaybackEntryRepository(DatabaseHelper);
+        var cancellationToken = CancellationToken.None;
+
+        // Ensure a clean database.
+        await CleanDatabaseAsync(repository);
+
+        // Try to delete a non-existent entry
+        var deletedCount = await repository.DeleteByIdAsync(999999, cancellationToken);
+        Assert.Equal(0, deletedCount);
+    }
+
+    [Fact]
+    public async Task DeleteByIdAsync_IncompleteEntry_DeletesEntry()
+    {
+        var repository = new PlaybackEntryRepository(DatabaseHelper);
+        var cancellationToken = CancellationToken.None;
+
+        // Ensure a clean database.
+        await CleanDatabaseAsync(repository);
+
+        // Create an incomplete entry (EndTime = null)
+        var entry = CreateEntry(DateTimeOffset.UtcNow.AddMinutes(-10), null, ContentType.Movie);
+
+        await repository.AppendAsync(entry, cancellationToken);
+
+        // Verify entry exists
+        var playbackId = entry.PlaybackId;
+        var retrieved = await repository.GetRecentlyIncompletedByPlaybackIdAsync(playbackId, cancellationToken);
+        Assert.NotNull(retrieved);
+
+        // Delete the entry
+        var deletedCount = await repository.DeleteByIdAsync(retrieved.Id, cancellationToken);
+        Assert.Equal(1, deletedCount);
+
+        // Verify entry no longer exists
+        var afterDelete = await repository.GetRecentlyIncompletedByPlaybackIdAsync(playbackId, cancellationToken);
+        Assert.Null(afterDelete);
+    }
 }

--- a/plugin/Jellyfin.Plugin.Jellydash.Tests/PlaybackEntryTests.cs
+++ b/plugin/Jellyfin.Plugin.Jellydash.Tests/PlaybackEntryTests.cs
@@ -1,0 +1,195 @@
+using Jellyfin.Plugin.Jellydash.Models;
+
+namespace Jellyfin.Plugin.Jellydash.Tests;
+
+/// <summary>
+/// Tests for PlaybackEntry business logic methods.
+/// </summary>
+[Collection("JellydashPluginTests")]
+public class PlaybackEntryTests
+{
+    [Fact]
+    public void ShouldTrackInHistory_NullRuntimeTicks_ReturnsTrue()
+    {
+        var entry = new PlaybackEntry
+        {
+            PlaybackId = Guid.NewGuid(),
+            RuntimeTicks = null,
+            StartPositionTicks = 0,
+            EndPositionTicks = 10_000_000L
+        };
+
+        var result = entry.ShouldTrackInHistory(20);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldTrackInHistory_ZeroRuntimeTicks_ReturnsTrue()
+    {
+        var entry = new PlaybackEntry
+        {
+            PlaybackId = Guid.NewGuid(),
+            RuntimeTicks = 0,
+            StartPositionTicks = 0,
+            EndPositionTicks = 10_000_000L
+        };
+
+        var result = entry.ShouldTrackInHistory(20);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldTrackInHistory_NullEndPosition_ReturnsFalse()
+    {
+        var entry = new PlaybackEntry
+        {
+            PlaybackId = Guid.NewGuid(),
+            RuntimeTicks = 100_000_000L,
+            StartPositionTicks = 0,
+            EndPositionTicks = null
+        };
+
+        var result = entry.ShouldTrackInHistory(20);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ShouldTrackInHistory_NullMinResumePct_ReturnsTrue()
+    {
+        var entry = new PlaybackEntry
+        {
+            PlaybackId = Guid.NewGuid(),
+            RuntimeTicks = 100_000_000L,
+            StartPositionTicks = 0,
+            EndPositionTicks = 1_000_000L // Only 1%
+        };
+
+        var result = entry.ShouldTrackInHistory(null);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldTrackInHistory_ZeroMinResumePct_ReturnsTrue()
+    {
+        var entry = new PlaybackEntry
+        {
+            PlaybackId = Guid.NewGuid(),
+            RuntimeTicks = 100_000_000L,
+            StartPositionTicks = 0,
+            EndPositionTicks = 1_000_000L // Only 1%
+        };
+
+        var result = entry.ShouldTrackInHistory(0);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldTrackInHistory_BelowMinimumThreshold_ReturnsFalse()
+    {
+        var entry = new PlaybackEntry
+        {
+            PlaybackId = Guid.NewGuid(),
+            RuntimeTicks = 100_000_000L,
+            StartPositionTicks = 0,
+            EndPositionTicks = 10_000_000L // 10%
+        };
+
+        var result = entry.ShouldTrackInHistory(20);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ShouldTrackInHistory_ExactlyAtMinimumThreshold_ReturnsTrue()
+    {
+        var entry = new PlaybackEntry
+        {
+            PlaybackId = Guid.NewGuid(),
+            RuntimeTicks = 100_000_000L,
+            StartPositionTicks = 0,
+            EndPositionTicks = 20_000_000L // Exactly 20%
+        };
+
+        var result = entry.ShouldTrackInHistory(20);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldTrackInHistory_AboveMinimumThreshold_ReturnsTrue()
+    {
+        var entry = new PlaybackEntry
+        {
+            PlaybackId = Guid.NewGuid(),
+            RuntimeTicks = 100_000_000L,
+            StartPositionTicks = 0,
+            EndPositionTicks = 50_000_000L // 50%
+        };
+
+        var result = entry.ShouldTrackInHistory(20);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldTrackInHistory_WithNonZeroStartPosition_CalculatesCorrectly()
+    {
+        var entry = new PlaybackEntry
+        {
+            PlaybackId = Guid.NewGuid(),
+            RuntimeTicks = 100_000_000L,
+            StartPositionTicks = 10_000_000L, // Started at 10%
+            EndPositionTicks = 35_000_000L // Ended at 35%, watched 25%
+        };
+
+        var result = entry.ShouldTrackInHistory(20);
+
+        // Watched 25% (from 10% to 35%), which is >= 20%
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldTrackInHistory_WithNonZeroStartPosition_BelowThreshold_ReturnsFalse()
+    {
+        var entry = new PlaybackEntry
+        {
+            PlaybackId = Guid.NewGuid(),
+            RuntimeTicks = 100_000_000L,
+            StartPositionTicks = 10_000_000L, // Started at 10%
+            EndPositionTicks = 25_000_000L // Ended at 25%, watched only 15%
+        };
+
+        var result = entry.ShouldTrackInHistory(20);
+
+        // Watched only 15% (from 10% to 25%), which is < 20%
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ShouldTrackInHistory_NearBoundary_RoundingDoesNotAffectResult()
+    {
+        var entry = new PlaybackEntry
+        {
+            PlaybackId = Guid.NewGuid(),
+            RuntimeTicks = 100_000_000L,
+            StartPositionTicks = 0,
+            EndPositionTicks = 19_999_999L // Just below 20%
+        };
+
+        var belowThreshold = entry.ShouldTrackInHistory(20);
+        Assert.False(belowThreshold);
+
+        entry.EndPositionTicks = 20_000_000L; // Exactly 20%
+        var atThreshold = entry.ShouldTrackInHistory(20);
+        Assert.True(atThreshold);
+
+        entry.EndPositionTicks = 20_000_001L; // Just above 20%
+        var aboveThreshold = entry.ShouldTrackInHistory(20);
+        Assert.True(aboveThreshold);
+    }
+}

--- a/plugin/Jellyfin.Plugin.Jellydash.Tests/PlaybackTrackerTests.cs
+++ b/plugin/Jellyfin.Plugin.Jellydash.Tests/PlaybackTrackerTests.cs
@@ -2,6 +2,7 @@ using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.Jellydash.Events;
 using Jellyfin.Plugin.Jellydash.Models;
 using Jellyfin.Plugin.Jellydash.Services;
+using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Events.Session;
@@ -32,7 +33,7 @@ public sealed class PlaybackTrackerTests
         return repo;
     }
 
-    private static PlaybackTracker CreateTracker()
+    private static PlaybackTracker CreateTracker(int? minResumePct = 20, int? maxResumePct = 90)
     {
         var logger = Mock.Of<ILogger<PlaybackTracker>>();
         var tempPath = Path.Combine(Path.GetTempPath(), "PlaybackTrackerTests");
@@ -41,7 +42,14 @@ public sealed class PlaybackTrackerTests
             Mock.Of<ILibraryManager>(),
             Mock.Of<ILogger<ImageCaptureService>>(),
             tempPath);
-        return new PlaybackTracker(logger, DatabaseHelper, imageCaptureService);
+
+        var mockConfig = new Mock<IServerConfigurationManager>();
+        var configuration = new MediaBrowser.Model.Configuration.ServerConfiguration();
+        configuration.MinResumePct = minResumePct ?? 20;
+        configuration.MaxResumePct = maxResumePct ?? 90;
+        mockConfig.Setup(c => c.Configuration).Returns(configuration);
+
+        return new PlaybackTracker(logger, DatabaseHelper, imageCaptureService, mockConfig.Object);
     }
 
     [Fact]
@@ -225,5 +233,324 @@ public sealed class PlaybackTrackerTests
             DeviceName = "device",
             Item = mockItem
         };
+    }
+
+    [Fact]
+    public async Task OnEvent_StopBelowMinimumThreshold_DoesNotMarkCompleted()
+    {
+        var repo = await CreateRepositoryAsync();
+        var tracker = CreateTracker(minResumePct: 20, maxResumePct: 90);
+
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+
+        // Watch only 10% (below 20% threshold)
+        var startArgs = CreatePlaybackStartEventArgs(userId, itemId, BaseItemKind.Movie, 100_000_000L, 0L);
+        await tracker.OnEvent(startArgs);
+
+        var stopArgs = CreatePlaybackStopEventArgs(userId, itemId, BaseItemKind.Movie, 100_000_000L, 10_000_000L, startArgs.Session.Id, startArgs.Session.PlaylistItemId);
+        await tracker.OnEvent(stopArgs);
+
+        var playbackId = PlaybackEntry.GeneratePlaybackId(stopArgs.Session.Id, stopArgs.Session.PlaylistItemId, stopArgs.MediaInfo.Id);
+        var completedEntry = await repo.GetRecentlyCompletedByPlaybackIdAsync(playbackId, CancellationToken.None);
+        Assert.Null(completedEntry); // Should not be in completed
+
+        var incompleteEntry = await repo.GetRecentlyIncompletedByPlaybackIdAsync(playbackId, CancellationToken.None);
+        Assert.Null(incompleteEntry); // Should be deleted when below threshold
+    }
+
+    [Fact]
+    public async Task OnEvent_StopBetweenThresholds_MarksCompletedWithOriginalPosition()
+    {
+        var repo = await CreateRepositoryAsync();
+        var tracker = CreateTracker(minResumePct: 20, maxResumePct: 90);
+
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+
+        // Watch 50% (between 20% and 90%)
+        var startArgs = CreatePlaybackStartEventArgs(userId, itemId, BaseItemKind.Movie, 100_000_000L, 0L);
+        await tracker.OnEvent(startArgs);
+
+        var stopArgs = CreatePlaybackStopEventArgs(userId, itemId, BaseItemKind.Movie, 100_000_000L, 50_000_000L, startArgs.Session.Id, startArgs.Session.PlaylistItemId);
+        await tracker.OnEvent(stopArgs);
+
+        var playbackId = PlaybackEntry.GeneratePlaybackId(stopArgs.Session.Id, stopArgs.Session.PlaylistItemId, stopArgs.MediaInfo.Id);
+        var entry = await repo.GetRecentlyCompletedByPlaybackIdAsync(playbackId, CancellationToken.None);
+        Assert.NotNull(entry);
+        Assert.True(entry.IsCompleted);
+        Assert.Equal(50_000_000L, entry.EndPositionTicks); // Original position, not normalized
+    }
+
+    [Fact]
+    public async Task OnEvent_StopAboveMaximumThreshold_MarksCompletedAndNormalizesPosition()
+    {
+        var repo = await CreateRepositoryAsync();
+        var tracker = CreateTracker(minResumePct: 20, maxResumePct: 90);
+
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+
+        // Watch 95% (above 90% threshold)
+        var startArgs = CreatePlaybackStartEventArgs(userId, itemId, BaseItemKind.Movie, 100_000_000L, 0L);
+        await tracker.OnEvent(startArgs);
+
+        var stopArgs = CreatePlaybackStopEventArgs(userId, itemId, BaseItemKind.Movie, 100_000_000L, 95_000_000L, startArgs.Session.Id, startArgs.Session.PlaylistItemId);
+        await tracker.OnEvent(stopArgs);
+
+        var playbackId = PlaybackEntry.GeneratePlaybackId(stopArgs.Session.Id, stopArgs.Session.PlaylistItemId, stopArgs.MediaInfo.Id);
+        var entry = await repo.GetRecentlyCompletedByPlaybackIdAsync(playbackId, CancellationToken.None);
+        Assert.NotNull(entry);
+        Assert.True(entry.IsCompleted);
+        Assert.Equal(100_000_000L, entry.EndPositionTicks); // Normalized to runtime
+    }
+
+    [Fact]
+    public async Task OnEvent_StopWithNullRuntimeTicks_AlwaysMarksCompleted()
+    {
+        var repo = await CreateRepositoryAsync();
+        var tracker = CreateTracker(minResumePct: 20, maxResumePct: 90);
+
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+
+        // null runtime (live TV or unknown duration)
+        var user = new Database.Implementations.Entities.User("User", "auth", "reset") { Id = userId };
+        var media = new MediaBrowser.Model.Dto.BaseItemDto
+        {
+            Id = itemId,
+            Name = "Item",
+            Type = BaseItemKind.Movie,
+            MediaType = MediaType.Video,
+            RunTimeTicks = null // No runtime
+        };
+
+        var mockSessionManager = new Mock<ISessionManager>().Object;
+        var mockLogger = new Mock<ILogger<SessionInfo>>().Object;
+        var session = new SessionInfo(mockSessionManager, mockLogger)
+        {
+            Id = Guid.NewGuid().ToString(),
+            PlaylistItemId = Guid.NewGuid().ToString(),
+            LastPlaybackCheckIn = DateTime.UtcNow
+        };
+
+        var mockItem = new Movie { Id = itemId, Name = "Item" };
+
+        var stopArgs = new PlaybackStopEventArgs
+        {
+            Users = [user],
+            MediaInfo = media,
+            PlaybackPositionTicks = 5_000_000L,
+            Session = session,
+            ClientName = "client",
+            DeviceName = "device",
+            Item = mockItem
+        };
+
+        await tracker.OnEvent(stopArgs);
+
+        var playbackId = PlaybackEntry.GeneratePlaybackId(stopArgs.Session.Id, stopArgs.Session.PlaylistItemId, stopArgs.MediaInfo.Id);
+        var entry = await repo.GetRecentlyCompletedByPlaybackIdAsync(playbackId, CancellationToken.None);
+        Assert.NotNull(entry);
+        Assert.True(entry.IsCompleted); // Should always mark completed for null runtime
+    }
+
+    [Fact]
+    public async Task OnEvent_StopWithZeroConfigThresholds_AlwaysMarksCompleted()
+    {
+        var repo = await CreateRepositoryAsync();
+        var tracker = CreateTracker(minResumePct: 0, maxResumePct: 0);
+
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+
+        // Watch only 1% with zero config thresholds
+        var startArgs = CreatePlaybackStartEventArgs(userId, itemId, BaseItemKind.Movie, 100_000_000L, 0L);
+        await tracker.OnEvent(startArgs);
+
+        var stopArgs = CreatePlaybackStopEventArgs(userId, itemId, BaseItemKind.Movie, 100_000_000L, 1_000_000L, startArgs.Session.Id, startArgs.Session.PlaylistItemId);
+        await tracker.OnEvent(stopArgs);
+
+        var playbackId = PlaybackEntry.GeneratePlaybackId(stopArgs.Session.Id, stopArgs.Session.PlaylistItemId, stopArgs.MediaInfo.Id);
+        var entry = await repo.GetRecentlyCompletedByPlaybackIdAsync(playbackId, CancellationToken.None);
+        Assert.NotNull(entry);
+        Assert.True(entry.IsCompleted); // Zero thresholds = any progress marks completed
+        Assert.Equal(1_000_000L, entry.EndPositionTicks); // Not normalized (maxResumePct is 0)
+    }
+
+    [Fact]
+    public async Task OnEvent_SessionEndedBelowMinimumThreshold_DoesNotMarkCompleted()
+    {
+        var repo = await CreateRepositoryAsync();
+        var tracker = CreateTracker(minResumePct: 20, maxResumePct: 90);
+
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+
+        // Start playback
+        var startArgs = CreatePlaybackStartEventArgs(userId, itemId, BaseItemKind.Movie, 100_000_000L, 0L);
+        await tracker.OnEvent(startArgs);
+
+        // Session ends after watching only 10% (below threshold)
+        startArgs.Session.UserId = userId;
+        startArgs.Session.NowPlayingItem = startArgs.MediaInfo;
+        startArgs.Session.PlayState.PositionTicks = 10_000_000L;
+        startArgs.Session.LastPlaybackCheckIn = DateTime.UtcNow;
+
+        var endedArgs = new SessionEndedEventArgs(startArgs.Session);
+        await tracker.OnEvent(endedArgs);
+
+        var playbackId = PlaybackEntry.GeneratePlaybackId(startArgs.Session.Id, startArgs.Session.PlaylistItemId, startArgs.MediaInfo.Id);
+        var completedEntry = await repo.GetRecentlyCompletedByPlaybackIdAsync(playbackId, CancellationToken.None);
+        Assert.Null(completedEntry);
+
+        var incompleteEntry = await repo.GetRecentlyIncompletedByPlaybackIdAsync(playbackId, CancellationToken.None);
+        Assert.Null(incompleteEntry); // Should be deleted when below threshold
+    }
+
+    [Fact]
+    public async Task OnEvent_SessionEndedAboveMaximumThreshold_MarksCompletedAndNormalizesPosition()
+    {
+        var repo = await CreateRepositoryAsync();
+        var tracker = CreateTracker(minResumePct: 20, maxResumePct: 90);
+
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+
+        // Start playback
+        var startArgs = CreatePlaybackStartEventArgs(userId, itemId, BaseItemKind.Movie, 100_000_000L, 0L);
+        await tracker.OnEvent(startArgs);
+
+        // Session ends after watching 92% (above maximum threshold)
+        startArgs.Session.UserId = userId;
+        startArgs.Session.NowPlayingItem = startArgs.MediaInfo;
+        startArgs.Session.PlayState.PositionTicks = 92_000_000L;
+        startArgs.Session.LastPlaybackCheckIn = DateTime.UtcNow;
+
+        var endedArgs = new SessionEndedEventArgs(startArgs.Session);
+        await tracker.OnEvent(endedArgs);
+
+        var playbackId = PlaybackEntry.GeneratePlaybackId(startArgs.Session.Id, startArgs.Session.PlaylistItemId, startArgs.MediaInfo.Id);
+        var entry = await repo.GetRecentlyCompletedByPlaybackIdAsync(playbackId, CancellationToken.None);
+        Assert.NotNull(entry);
+        Assert.True(entry.IsCompleted);
+        Assert.Equal(100_000_000L, entry.EndPositionTicks); // Normalized to runtime
+    }
+
+    [Fact]
+    public async Task OnEvent_SessionEndedWithNullRuntimeTicks_AlwaysMarksCompleted()
+    {
+        var repo = await CreateRepositoryAsync();
+        var tracker = CreateTracker(minResumePct: 20, maxResumePct: 90);
+
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+
+        // Create a start event with null runtime
+        var user = new Database.Implementations.Entities.User("User", "auth", "reset") { Id = userId };
+        var media = new MediaBrowser.Model.Dto.BaseItemDto
+        {
+            Id = itemId,
+            Name = "LiveTV",
+            Type = BaseItemKind.Movie,
+            MediaType = MediaType.Video,
+            RunTimeTicks = null // No runtime (live TV or unknown)
+        };
+
+        var mockSessionManager = new Mock<ISessionManager>().Object;
+        var mockLogger = new Mock<ILogger<SessionInfo>>().Object;
+        var session = new SessionInfo(mockSessionManager, mockLogger)
+        {
+            Id = Guid.NewGuid().ToString(),
+            PlaylistItemId = Guid.NewGuid().ToString(),
+            LastPlaybackCheckIn = DateTime.UtcNow
+        };
+
+        var mockItem = new Movie { Id = itemId, Name = "LiveTV" };
+
+        var startArgs = new PlaybackStartEventArgs
+        {
+            Users = [user],
+            MediaInfo = media,
+            PlaybackPositionTicks = 0L,
+            Session = session,
+            ClientName = "client",
+            DeviceName = "device",
+            Item = mockItem
+        };
+
+        await tracker.OnEvent(startArgs);
+
+        // Session ends after watching some duration
+        session.UserId = userId;
+        session.NowPlayingItem = media;
+        session.PlayState.PositionTicks = 5_000_000L;
+        session.LastPlaybackCheckIn = DateTime.UtcNow;
+
+        var endedArgs = new SessionEndedEventArgs(session);
+        await tracker.OnEvent(endedArgs);
+
+        var playbackId = PlaybackEntry.GeneratePlaybackId(session.Id, session.PlaylistItemId, media.Id);
+        var entry = await repo.GetRecentlyCompletedByPlaybackIdAsync(playbackId, CancellationToken.None);
+        Assert.NotNull(entry);
+        Assert.True(entry.IsCompleted); // Should always mark completed for null runtime
+    }
+
+    [Fact]
+    public async Task OnEvent_SessionEndedBetweenThresholds_MarksCompletedWithOriginalPosition()
+    {
+        var repo = await CreateRepositoryAsync();
+        var tracker = CreateTracker(minResumePct: 20, maxResumePct: 90);
+
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+
+        // Start playback
+        var startArgs = CreatePlaybackStartEventArgs(userId, itemId, BaseItemKind.Movie, 100_000_000L, 0L);
+        await tracker.OnEvent(startArgs);
+
+        // Session ends after watching 50% (between thresholds)
+        startArgs.Session.UserId = userId;
+        startArgs.Session.NowPlayingItem = startArgs.MediaInfo;
+        startArgs.Session.PlayState.PositionTicks = 50_000_000L;
+        startArgs.Session.LastPlaybackCheckIn = DateTime.UtcNow;
+
+        var endedArgs = new SessionEndedEventArgs(startArgs.Session);
+        await tracker.OnEvent(endedArgs);
+
+        var playbackId = PlaybackEntry.GeneratePlaybackId(startArgs.Session.Id, startArgs.Session.PlaylistItemId, startArgs.MediaInfo.Id);
+        var entry = await repo.GetRecentlyCompletedByPlaybackIdAsync(playbackId, CancellationToken.None);
+        Assert.NotNull(entry);
+        Assert.True(entry.IsCompleted);
+        Assert.Equal(50_000_000L, entry.EndPositionTicks); // Original position, not normalized
+    }
+
+    [Fact]
+    public async Task OnEvent_SessionEndedWithZeroConfigThresholds_AlwaysMarksCompleted()
+    {
+        var repo = await CreateRepositoryAsync();
+        var tracker = CreateTracker(minResumePct: 0, maxResumePct: 0);
+
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+
+        // Start playback
+        var startArgs = CreatePlaybackStartEventArgs(userId, itemId, BaseItemKind.Movie, 100_000_000L, 0L);
+        await tracker.OnEvent(startArgs);
+
+        // Session ends after watching only 1% with zero config thresholds
+        startArgs.Session.UserId = userId;
+        startArgs.Session.NowPlayingItem = startArgs.MediaInfo;
+        startArgs.Session.PlayState.PositionTicks = 1_000_000L;
+        startArgs.Session.LastPlaybackCheckIn = DateTime.UtcNow;
+
+        var endedArgs = new SessionEndedEventArgs(startArgs.Session);
+        await tracker.OnEvent(endedArgs);
+
+        var playbackId = PlaybackEntry.GeneratePlaybackId(startArgs.Session.Id, startArgs.Session.PlaylistItemId, startArgs.MediaInfo.Id);
+        var entry = await repo.GetRecentlyCompletedByPlaybackIdAsync(playbackId, CancellationToken.None);
+        Assert.NotNull(entry);
+        Assert.True(entry.IsCompleted); // Zero thresholds = any progress marks completed
+        Assert.Equal(1_000_000L, entry.EndPositionTicks); // Not normalized (maxResumePct is 0)
     }
 }

--- a/plugin/Jellyfin.Plugin.Jellydash/Events/PlaybackTracker.cs
+++ b/plugin/Jellyfin.Plugin.Jellydash/Events/PlaybackTracker.cs
@@ -1,16 +1,13 @@
 using System;
-using System.Linq;
-using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.Jellydash.Models;
 using Jellyfin.Plugin.Jellydash.Services;
+using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Events.Session;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Dto;
-using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.Jellydash.Events;
@@ -27,6 +24,7 @@ public class PlaybackTracker :
     private readonly ILogger<PlaybackTracker> _logger;
     private readonly PlaybackEntryRepository _repository;
     private readonly ImageCaptureService _imageCaptureService;
+    private readonly IServerConfigurationManager _configurationManager;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PlaybackTracker"/> class.
@@ -34,14 +32,17 @@ public class PlaybackTracker :
     /// <param name="logger">Logger instance.</param>
     /// <param name="databaseHelper">DatabaseHelper instance.</param>
     /// <param name="imageCaptureService">Image capture service.</param>
+    /// <param name="configurationManager">Server configuration manager for accessing resume percentage thresholds.</param>
     public PlaybackTracker(
         ILogger<PlaybackTracker> logger,
         DatabaseHelper databaseHelper,
-        ImageCaptureService imageCaptureService)
+        ImageCaptureService imageCaptureService,
+        IServerConfigurationManager configurationManager)
     {
         _logger = logger;
         _repository = new PlaybackEntryRepository(databaseHelper);
         _imageCaptureService = imageCaptureService;
+        _configurationManager = configurationManager;
     }
 
     /// <inheritdoc />
@@ -117,8 +118,17 @@ public class PlaybackTracker :
                 imageHash = await _imageCaptureService.CaptureImageAsync(eventArgs.Item, contentType, default).ConfigureAwait(false);
             }
 
-            var entry = PlaybackEntry.FromStopEvent(existing, eventArgs, imageHash);
-            await _repository.Upsert(entry, default).ConfigureAwait(false);
+            var minResumePct = _configurationManager.Configuration.MinResumePct;
+            var maxResumePct = _configurationManager.Configuration.MaxResumePct;
+            var entry = PlaybackEntry.FromStopEvent(existing, eventArgs, imageHash, maxResumePct);
+            if (entry.ShouldTrackInHistory(minResumePct))
+            {
+                await _repository.Upsert(entry, default).ConfigureAwait(false);
+            }
+            else if (existing is not null)
+            {
+                await _repository.DeleteByIdAsync(existing.Id, default).ConfigureAwait(false);
+            }
         }
         catch (Exception ex)
         {
@@ -145,8 +155,17 @@ public class PlaybackTracker :
                 return;
             }
 
-            var entry = PlaybackEntry.FromSessionEndedEvent(existing, eventArgs);
-            await _repository.Upsert(entry, default).ConfigureAwait(false);
+            var minResumePct = _configurationManager.Configuration.MinResumePct;
+            var maxResumePct = _configurationManager.Configuration.MaxResumePct;
+            var entry = PlaybackEntry.FromSessionEndedEvent(existing, eventArgs, maxResumePct);
+            if (entry.ShouldTrackInHistory(minResumePct))
+            {
+                await _repository.Upsert(entry, default).ConfigureAwait(false);
+            }
+            else
+            {
+                await _repository.DeleteByIdAsync(existing.Id, default).ConfigureAwait(false);
+            }
         }
         catch (Exception ex)
         {

--- a/plugin/Jellyfin.Plugin.Jellydash/Models/ActivityResponse.cs
+++ b/plugin/Jellyfin.Plugin.Jellydash/Models/ActivityResponse.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
 namespace Jellyfin.Plugin.Jellydash.Models

--- a/plugin/Jellyfin.Plugin.Jellydash/Models/PlaybackEntry.cs
+++ b/plugin/Jellyfin.Plugin.Jellydash/Models/PlaybackEntry.cs
@@ -1,14 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
-using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Events.Session;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Entities;
-using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace Jellyfin.Plugin.Jellydash.Models;
 
@@ -354,17 +351,25 @@ public class PlaybackEntry
     /// <param name="imageHash">
     /// The hash of the captured image for the playback item.
     /// </param>
+    /// <param name="maxResumePct">
+    /// The maximum resume percentage threshold from Jellyfin configuration.
+    /// </param>
     /// <returns>
-    /// A <see cref="PlaybackEntry"/> initialized from the event and marked as completed.
+    /// A <see cref="PlaybackEntry"/> initialized from the event and conditionally marked as completed based on thresholds.
     /// </returns>
-    public static PlaybackEntry FromStopEvent(PlaybackEntry? existing, PlaybackStopEventArgs eventArgs, string? imageHash)
+    public static PlaybackEntry FromStopEvent(
+        PlaybackEntry? existing,
+        PlaybackStopEventArgs eventArgs,
+        string? imageHash,
+        int? maxResumePct)
     {
         var entry = existing ?? FromEvent(eventArgs);
         // For stop events, set the end time and final position.
         entry.StartTime = existing?.StartTime ?? DateTimeOffset.UtcNow;
         entry.StartPositionTicks = existing?.StartPositionTicks ?? 0;
+        var endPosition = eventArgs.PlaybackPositionTicks ?? 0;
+        entry.EndPositionTicks = NormalizeEndPosition(endPosition, entry.RuntimeTicks, maxResumePct);
         entry.IsCompleted = true;
-        entry.EndPositionTicks = eventArgs.PlaybackPositionTicks ?? 0;
         entry.IsPaused = false;
         entry.EndTime = eventArgs.Session.LastPlaybackCheckIn;
         entry.ItemImageHash = existing?.ItemImageHash ?? imageHash ?? null;
@@ -376,13 +381,20 @@ public class PlaybackEntry
     /// </summary>
     /// <param name="existing">The existing <see cref="PlaybackEntry"/> to update.</param>
     /// <param name="eventArgs">The session ended event containing the final playback state and timestamp.</param>
+    /// <param name="maxResumePct">
+    /// The maximum resume percentage threshold from Jellyfin configuration.
+    /// </param>
     /// <returns>
-    /// The updated <see cref="PlaybackEntry"/> marked as completed and with the final playback position and end time.
+    /// The updated <see cref="PlaybackEntry"/> conditionally marked as completed based on thresholds and with the final playback position and end time.
     /// </returns>
-    public static PlaybackEntry FromSessionEndedEvent(PlaybackEntry existing, SessionEndedEventArgs eventArgs)
+    public static PlaybackEntry FromSessionEndedEvent(
+        PlaybackEntry existing,
+        SessionEndedEventArgs eventArgs,
+        int? maxResumePct)
     {
         var entry = existing;
-        entry.EndPositionTicks = eventArgs.Argument.PlayState?.PositionTicks ?? existing.EndPositionTicks;
+        var endPosition = eventArgs.Argument.PlayState?.PositionTicks ?? existing.EndPositionTicks;
+        entry.EndPositionTicks = NormalizeEndPosition(endPosition, entry.RuntimeTicks, maxResumePct);
         entry.IsPaused = false;
         entry.IsCompleted = true;
         entry.EndTime = eventArgs.Argument.LastPlaybackCheckIn;
@@ -396,6 +408,83 @@ public class PlaybackEntry
         entry.TranscodeReasonsJson = null;
         entry.TranscodeCompletionPercentage = null;
         return entry;
+    }
+
+    /// <summary>
+    /// Determines whether a playback entry should be marked as completed based on Jellyfin's resume percentage thresholds.
+    /// </summary>
+    /// <param name="minResumePct">The minimum resume percentage threshold (0-100). If null or zero, any progress marks as completed.</param>
+    /// <returns>True if the playback should be marked as completed; otherwise, false.</returns>
+    /// <remarks>
+    /// If RuntimeTicks is null or zero (e.g., live TV or unknown duration), always returns true.
+    /// If MinResumePct is null or zero, any playback progress marks as completed.
+    /// Otherwise, completion requires the actual watched duration (EndPositionTicks - StartPositionTicks) as a percentage of RuntimeTicks to be >= MinResumePct.
+    /// </remarks>
+    public bool ShouldTrackInHistory(int? minResumePct)
+    {
+        // If we don't have valid runtime, mark as completed (live TV / unknown duration).
+        if (!RuntimeTicks.HasValue || RuntimeTicks.Value <= 0)
+        {
+            return true;
+        }
+
+        // If we don't have a valid end position, cannot be completed.
+        if (!EndPositionTicks.HasValue)
+        {
+            return false;
+        }
+
+        // If minimum threshold is null or zero, any playback marks as completed.
+        int minThreshold = minResumePct ?? 0;
+        if (minThreshold <= 0)
+        {
+            return true;
+        }
+
+        // Calculate the actual watched duration and compare to minimum threshold.
+        long watchedDuration = EndPositionTicks.Value - (StartPositionTicks ?? 0);
+        double percentage = (double)watchedDuration / RuntimeTicks.Value * 100.0;
+        return percentage >= minThreshold;
+    }
+
+    /// <summary>
+    /// Normalizes the end position to the runtime when the maximum resume percentage threshold is exceeded.
+    /// </summary>
+    /// <param name="endPositionTicks">The final playback position in ticks.</param>
+    /// <param name="runtimeTicks">The total runtime of the item in ticks.</param>
+    /// <param name="maxResumePct">The maximum resume percentage threshold (0-100). If null or zero, no normalization occurs.</param>
+    /// <returns>The normalized end position in ticks.</returns>
+    /// <remarks>
+    /// When playback exceeds MaxResumePct, the position is clamped to RuntimeTicks to indicate full completion.
+    /// If RuntimeTicks is null or zero, returns the original EndPositionTicks.
+    /// If MaxResumePct is null or zero, returns the original EndPositionTicks.
+    /// </remarks>
+    private static long? NormalizeEndPosition(
+        long? endPositionTicks,
+        long? runtimeTicks,
+        int? maxResumePct)
+    {
+        // If we don't have valid runtime or position, return as-is.
+        if (!runtimeTicks.HasValue || runtimeTicks.Value <= 0 || !endPositionTicks.HasValue)
+        {
+            return endPositionTicks;
+        }
+
+        // If maximum threshold is null or zero, no normalization needed.
+        int maxThreshold = maxResumePct ?? 0;
+        if (maxThreshold <= 0)
+        {
+            return endPositionTicks;
+        }
+
+        // If watch percentage exceeds maximum, clamp to runtime.
+        double percentage = (double)endPositionTicks.Value / runtimeTicks.Value * 100.0;
+        if (percentage >= maxThreshold)
+        {
+            return runtimeTicks.Value;
+        }
+
+        return endPositionTicks;
     }
 
     /// <summary>

--- a/plugin/Jellyfin.Plugin.Jellydash/Plugin.cs
+++ b/plugin/Jellyfin.Plugin.Jellydash/Plugin.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Threading;
 using Jellyfin.Plugin.Jellydash.Configuration;
-using Jellyfin.Plugin.Jellydash.Services;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Plugins;

--- a/plugin/Jellyfin.Plugin.Jellydash/Services/DatabaseHelper.cs
+++ b/plugin/Jellyfin.Plugin.Jellydash/Services/DatabaseHelper.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Threading;
 using Dapper;
 using Jellyfin.Plugin.Jellydash.TypeMappers;
 using Microsoft.Data.Sqlite;

--- a/plugin/Jellyfin.Plugin.Jellydash/Services/ImageCaptureService.cs
+++ b/plugin/Jellyfin.Plugin.Jellydash/Services/ImageCaptureService.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;

--- a/plugin/Jellyfin.Plugin.Jellydash/Services/JellydashServiceRegistrator.cs
+++ b/plugin/Jellyfin.Plugin.Jellydash/Services/JellydashServiceRegistrator.cs
@@ -1,13 +1,10 @@
-using System.Threading;
 using Jellyfin.Plugin.Jellydash.Events;
-using Jellyfin.Plugin.Jellydash.Services;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Events;
 using MediaBrowser.Controller.Events.Session;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.Net.WebSocketMessages.Outbound;
 using MediaBrowser.Controller.Plugins;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/plugin/Jellyfin.Plugin.Jellydash/Services/PlaybackEntryRepository.cs
+++ b/plugin/Jellyfin.Plugin.Jellydash/Services/PlaybackEntryRepository.cs
@@ -219,6 +219,27 @@ LIMIT 1;";
     }
 
     /// <summary>
+    /// Deletes a playback entry from the database by its unique identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier of the playback entry to delete.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+    public async Task<int> DeleteByIdAsync(int id, CancellationToken cancellationToken)
+    {
+        await DbLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            using var connection = new SqliteConnection(_databaseHelper.ConnectionString);
+            var sql = "DELETE FROM PlaybackEntries WHERE Id = @Id;";
+            return await connection.ExecuteAsync(sql, new { Id = id }).ConfigureAwait(false);
+        }
+        finally
+        {
+            DbLock.Release();
+        }
+    }
+
+    /// <summary>
     /// Deletes entries older than the specified cutoff.
     /// </summary>
     /// <param name="cutoffUtc">UTC cutoff time.</param>


### PR DESCRIPTION
Don't keep sessions shorter than the minimumResume configuration (i.e. if less than 5 percent is played remove it before it becomes part of the history) and round entries within the maxResume configuration (i.e. if more than 90% is played, ensure it's stored as watching the full episode.