### PR TITLE
Fix: version number

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.0.3+1
+version: 0.0.3
 
 environment:
   sdk: '>=3.2.6 <4.0.0'


### PR DESCRIPTION
The previous build did not work because the version number was not valid for the Jellyfin Plugin. This PR fixes that by removing the build number from the version.

https://github.com/johman10/jellydash/actions/runs/21750692087/job/62747621650